### PR TITLE
feat: ✨Input(#25) 컴포넌트 커스터마이징

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -17,6 +17,7 @@ import {
   PaginationItem,
   PaginationLink,
 } from '@/components/ui/pagination';
+import { Input } from '@/components/common/Input';
 
 const data = Array(8).fill({
   id: 250,
@@ -38,6 +39,47 @@ const Dashboard = () => {
   }));
   return (
     <div className="p-6">
+      {/* 인풋 예시 */}
+      <div className="mb-8 p-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+          <div className="space-y-2">
+            <Input inputWidth="w221" placeholder="w221" />
+          </div>
+
+          <div className="space-y-2">
+            <Input inputWidth="w190" placeholder="w190" type="password" />
+          </div>
+
+          <div className="space-y-2">
+            <Input inputWidth="w167" defaultValue="w167" />
+          </div>
+
+          <div className="space-y-2">
+            <Input inputWidth="w167" defaultValue="readonly" readOnly />
+          </div>
+
+          <div className="space-y-2">
+            <Input inputWidth="w234" type="email" placeholder="w234" />
+          </div>
+
+          <div className="space-y-2">
+            <Input inputWidth="w358" type="email" placeholder="w358" />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Input inputWidth="w190" type="number" placeholder="w190" />
+            </div>
+          </div>
+
+          <div className="space-y-2 col-span-2">
+            <Input inputWidth="w598" placeholder="w598" />
+          </div>
+          <div className="space-y-2 col-span-3">
+            <Input inputWidth="w1130" placeholder="w1130" />
+          </div>
+        </div>
+      </div>
       {/* 테이블 상단 */}
       <div className="flex items-center justify-between mb-4">
         <span className="text-lg font-semibold">전체: 333</span>

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const inputVariants = cva(
+  'flex h-11 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-neutral-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:ring-offset-neutral-950 dark:placeholder:text-neutral-400 dark:focus-visible:ring-neutral-300',
+  {
+    variants: {
+      inputWidth: {
+        w167: 'w-[167px]', // 회원상세정보, 팝업공지관리 위치 입력
+        w190: 'w-[190px]', // 검색창 입력, 쿠폰명-할인금액
+        w221: 'w-[221px]', // 로그인창 입력
+        w234: 'w-[234px]', // email 입력
+        w358: 'w-[358px]', // 유저이메일 전체
+        w598: 'w-[598px]', // 계정생성
+        w650: 'w-[650px]',
+        w1130: 'w-[1130px]', // 제목 입력
+        full: 'w-full', // 전체 너비
+      },
+    },
+    defaultVariants: {
+      inputWidth: 'full',
+    },
+  },
+);
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {
+  containerClassName?: string;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    { className, inputWidth, type, containerClassName, defaultValue, ...props },
+    ref,
+  ) => {
+    return (
+      <div className={cn('flex flex-col gap-1.5', containerClassName)}>
+        <input
+          type={type}
+          className={cn(inputVariants({ inputWidth, className }))}
+          ref={ref}
+          defaultValue={defaultValue}
+          {...props}
+        />
+      </div>
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input, inputVariants };


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #25 

## 📝작업 내용
feat: ✨Input 컴포넌트 커스터마이징
```
    variants: {
      inputWidth: {
        w167: 'w-[167px]', // 회원상세정보, 팝업공지관리 위치 입력
        w190: 'w-[190px]', // 검색창 입력, 쿠폰명-할인금액
        w221: 'w-[221px]', // 로그인창 입력
        w234: 'w-[234px]', // email 입력
        w358: 'w-[358px]', // 유저이메일 전체
        w598: 'w-[598px]', // 계정생성
        w650: 'w-[650px]',
        w1130: 'w-[1130px]', // 제목 입력
        full: 'w-full', // 전체 너비
      },
```
- width 기준 variant 설정
- default value가 있는 경우 readOnly

### 스크린샷 (선택)
<img width="1474" alt="스크린샷 2025-03-05 오후 2 22 15" src="https://github.com/user-attachments/assets/4aa0f3e8-b0e7-4c78-beb6-eb4435ca2f66" />

## 💬리뷰 요구사항(선택)
`type = 'password'`에서 보기/숨기기 아이콘의 경우, Chromium 기반 브라우저에서만 표출됩니다.
타 브라우저에서도 보이도록 브라우저 종속성을 제거한 후 작업할지 고민입니다. 
