### PR TITLE
feat: ✨ (#27): Pagination 컴포넌트 생성

### DIFF
--- a/public/icons.tsx
+++ b/public/icons.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+export const LeftDoubleArrowIcon = () => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 3L3 8L8 13"
+        stroke="#343B42"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 3L8 8L13 13"
+        stroke="#343B42"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export const LeftArrowIcon = () => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11 3L6 8L11 13"
+        stroke="#343B42"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export const RightArrowIcon = () => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6 3L11 8L6 13"
+        stroke="#343B42"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export const RightDoubleArrowIcon = () => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 3L8 8L3 13"
+        stroke="#343B42"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 3L13 8L8 13"
+        stroke="#343B42"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,9 +14,13 @@ import { Checkbox } from '@/components/ui/checkbox';
 import {
   Pagination,
   PaginationContent,
+  PaginationFirst,
   PaginationItem,
+  PaginationLast,
   PaginationLink,
-} from '@/components/ui/pagination';
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/common/Pagination';
 import { Input } from '@/components/common/Input';
 import { Paperclip } from 'lucide-react';
 
@@ -163,6 +167,12 @@ const Dashboard = () => {
       <Pagination className="flex justify-center mt-4">
         <PaginationContent>
           <PaginationItem>
+            <PaginationFirst href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
             <PaginationLink href="#" isActive>
               1
             </PaginationLink>
@@ -178,6 +188,12 @@ const Dashboard = () => {
           </PaginationItem>
           <PaginationItem>
             <PaginationLink href="#">5</PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLast href="#" />
           </PaginationItem>
         </PaginationContent>
       </Pagination>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -19,6 +19,10 @@ const buttonVariants = cva(
           'bg-[#E2E9F2] hover:bg-[#E2E9F2]/90 hover:text-neutral-900 dark:hover:bg-neutral-900 dark:hover:text-neutral-50/90',
         danger:
           'bg-[#B00020] text-white hover:bg-[#B00020]/90 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-50/90',
+        pageActive:
+          'bg-[#F1F9FF] text-[#1D2022] hover:bg-[#F1F9FF]/90 w-8 h-8 rounded-full p-5 gap-2.5 font-normal text-base leading-[22px] tracking-[-0.6px] text-center font-spoqa',
+        pageDefault:
+          'bg-white text-[#8E959D] dark:border-neutral-800 dark:bg-neutral-950 w-8 h-8 rounded-full p-5 gap-2.5 font-normal text-base leading-[22px] tracking-[-0.6px] text-center font-spoqa',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,8 +1,19 @@
 import * as React from 'react';
-import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
+import { MoreHorizontal } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { ButtonProps, buttonVariants } from '@/components/common/Button';
+import {
+  LeftArrowIcon,
+  LeftDoubleArrowIcon,
+  RightArrowIcon,
+  RightDoubleArrowIcon,
+} from '../../../public/icons';
+
+type PaginationArrowProps = {
+  className?: string;
+  href?: string;
+} & React.HTMLAttributes<HTMLAnchorElement>;
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => {
   return (
@@ -32,7 +43,11 @@ const PaginationItem = React.forwardRef<
   HTMLLIElement,
   React.ComponentProps<'li'>
 >(({ className, ...props }, ref) => (
-  <li ref={ref} className={cn('', className)} {...props} />
+  <li
+    ref={ref}
+    className={cn('flex flex-row items-center gap-2.5', className)}
+    {...props}
+  />
 ));
 PaginationItem.displayName = 'PaginationItem';
 
@@ -53,7 +68,7 @@ const PaginationLink = ({
       aria-current={isActive ? 'page' : undefined}
       className={cn(
         buttonVariants({
-          variant: isActive ? 'outline' : 'ghost',
+          variant: isActive ? 'pageActive' : 'pageDefault',
           size,
         }),
         className,
@@ -69,39 +84,91 @@ PaginationLink.displayName = 'PaginationLink';
 
 const PaginationPrevious = ({
   className,
+  href,
   ...props
-}: React.ComponentProps<typeof PaginationLink>) => {
+}: PaginationArrowProps) => {
   return (
-    <PaginationLink
+    <a
+      href={href}
       aria-label="Go to previous page"
-      size="default"
-      className={cn('gap-1 pl-2.5', className)}
+      className={cn(
+        'flex items-center justify-center w-8 h-8 rounded-full bg-white text-[#1D2022]',
+        className,
+      )}
       {...props}
     >
-      <ChevronLeft className="w-4 h-4" />
+      <LeftArrowIcon />
       <span className="sr-only">Previous</span>
-    </PaginationLink>
+    </a>
   );
 };
 PaginationPrevious.displayName = 'PaginationPrevious';
 
 const PaginationNext = ({
   className,
+  href,
   ...props
-}: React.ComponentProps<typeof PaginationLink>) => {
+}: PaginationArrowProps) => {
   return (
-    <PaginationLink
+    <a
+      href={href}
       aria-label="Go to next page"
-      size="default"
-      className={cn('gap-1 pr-2.5', className)}
+      className={cn(
+        'flex items-center justify-center w-8 h-8 rounded-full bg-white text-[#1D2022]',
+        className,
+      )}
       {...props}
     >
       <span className="sr-only">Next</span>
-      <ChevronRight className="w-4 h-4" />
-    </PaginationLink>
+      <RightArrowIcon />
+    </a>
   );
 };
 PaginationNext.displayName = 'PaginationNext';
+
+const PaginationFirst = ({
+  className,
+  href,
+  ...props
+}: PaginationArrowProps) => {
+  return (
+    <a
+      href={href}
+      aria-label="Go to first page"
+      className={cn(
+        'flex items-center justify-center w-8 h-8 rounded-full bg-white text-[##1D2022]',
+        className,
+      )}
+      {...props}
+    >
+      <LeftDoubleArrowIcon />
+      <span className="sr-only">First pages</span>
+    </a>
+  );
+};
+PaginationFirst.displayName = 'PaginationFirst';
+
+const PaginationLast = ({
+  className,
+  href,
+  ...props
+}: PaginationArrowProps) => {
+  return (
+    <a
+      href={href}
+      aria-label="Go to last page"
+      className={cn(
+        'flex items-center justify-center w-8 h-8 rounded-full bg-white text-[#1D2022]',
+        className,
+      )}
+      {...props}
+    >
+      <span className="sr-only">Last pages</span>
+      <RightDoubleArrowIcon />
+    </a>
+  );
+};
+PaginationLast.displayName = 'PaginationLast';
 
 const PaginationEllipsis = ({
   className,
@@ -128,4 +195,6 @@ export {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
+  PaginationFirst,
+  PaginationLast,
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용
- Pagination UI
- 기본 페이지네이션 컨테이너 및 컨텐츠 컴포넌트 추가
- 페이지 번호 링크 컴포넌트 구현 (활성/비활성 상태 지원)
- 이전, 다음, 처음, 마지막 페이지 네비게이션 기능 추가
- 페이지 건너뛰기를 위한 생략(ellipsis) 컴포넌트 구현


### 스크린샷 (선택)
<img width="1619" alt="스크린샷 2025-03-23 오후 4 14 31" src="https://github.com/user-attachments/assets/8f7bd145-47f2-4ee3-8988-3bf4e8612155" />

## 💬리뷰 요구사항(선택)

> 
